### PR TITLE
SUPEE-6788

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## LoyaltyLion for Magento
 
-Version 1.0.2
+Version 1.0.3
 
 ### Compatibility
 
@@ -28,6 +28,7 @@ You'll need to add the LoyaltyLion UI elements to your store before the program 
 
 ### Changelog
 
+* 1.0.3: SUPEE-6788 compatibility
 * 1.0.2: supports sending discounts used when tracking orders
 * 1.0.1: supports sending loyaltylion `tracking_id` parameters
 * 1.0.0: initial release

--- a/app/code/local/LoyaltyLion/Core/etc/config.xml
+++ b/app/code/local/LoyaltyLion/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <LoyaltyLion_Core>
-      <version>0.0.1</version>
+      <version>0.0.2</version>
     </LoyaltyLion_Core>
   </modules>
   <global>

--- a/app/code/local/LoyaltyLion/Core/etc/config.xml
+++ b/app/code/local/LoyaltyLion/Core/etc/config.xml
@@ -112,15 +112,4 @@
       </resources>
     </acl>
   </adminhtml>
-  <admin>
-    <routers>
-      <loyaltylion>
-        <use>admin</use>
-        <args>
-          <module>LoyaltyLion_Core</module>
-          <frontName>loyaltylion</frontName>
-        </args>
-      </loyaltylion>
-    </routers>
-  </admin>
 </config>


### PR DESCRIPTION
Defining admin routes in this way is incompatible with a security patch contained in 1.9.2.2.

Since we don't actually have any admin controllers, this should be safe to delete entirely.

I've tested all the core functionality (signing up, purchases, referrals, redeeming voucher codes) and everything still works.