### PR TITLE
Use $ namespace for core events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## LoyaltyLion for Magento
 
-Version 1.1.6
+Version 1.1.7
 
 ### Compatibility
 
@@ -28,6 +28,7 @@ You'll need to add the LoyaltyLion UI elements to your store before the program 
 
 ### Changelog
 
+* 1.1.7: Use `$` namespace for core events
 * 1.1.6: Fix controller/model case sensitivity
 * 1.1.4: Fix default submission URL
 * 1.1.3: Fix oauth credential submission

--- a/app/code/local/LoyaltyLion/Core/Model/Observer.php
+++ b/app/code/local/LoyaltyLion/Core/Model/Observer.php
@@ -278,7 +278,7 @@ class LoyaltyLion_Core_Model_Observer {
     if ($tracking_id)
       $data['tracking_id'] = $tracking_id;
 
-    $response = $this->client->events->track('signup', $data);
+    $response = $this->client->events->track('$signup', $data);
 
     if ($response->success) {
       Mage::log('[LoyaltyLion] Tracked event [signup] OK');

--- a/app/code/local/LoyaltyLion/Core/etc/config.xml
+++ b/app/code/local/LoyaltyLion/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <LoyaltyLion_Core>
-      <version>0.0.3</version>
+      <version>0.0.4</version>
     </LoyaltyLion_Core>
   </modules>
   <global>

--- a/app/code/local/LoyaltyLion/Core/lib/loyaltylion-client/main.php
+++ b/app/code/local/LoyaltyLion/Core/lib/loyaltylion-client/main.php
@@ -90,7 +90,7 @@ class LoyaltyLion_Activities extends LoyaltyLion_Client {
   /**
    * Track an activity
    * 
-   * @param  [type] $name             The activity name, e.g. "signup"
+   * @param  [type] $name             The activity name, e.g. "$signup"
    * @param  array  $properties       Activity data
    * 
    * @return object                   An object with information about the request. If the track 


### PR DESCRIPTION
We now enforce `$` at the start of core loyaltylion events.