### PR TITLE
Allow importing voucher codes in the UI, to work around lack of API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Version 1.2.0
 
 ### Compatibility
 
-This module has been tested with Magento versions 1.7, 1.8 and 1.9.
+This module has been tested with Magento versions 1.6, 1.7, 1.8 and 1.9.
+Voucher import via the REST API is only supported on Magento >= 1.7.
 
 ### How to install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## LoyaltyLion for Magento
 
-Version 1.1.9
+Version 1.2.0
 
 ### Compatibility
 
@@ -28,6 +28,7 @@ You'll need to add the LoyaltyLion UI elements to your store before the program 
 
 ### Changelog
 
+* 1.2.0: Add support for importing voucher codes within your Magento Admin panel (Magento 1.6 only)
 * 1.1.9: Partial compatibility with Magento 1.6
 * 1.1.8: Update signup link
 * 1.1.7: Use `$` namespace for core events

--- a/app/code/local/LoyaltyLion/Core/etc/config.xml
+++ b/app/code/local/LoyaltyLion/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <LoyaltyLion_Core>
-      <version>0.0.6</version>
+      <version>0.0.7</version>
     </LoyaltyLion_Core>
   </modules>
   <global>

--- a/app/code/local/LoyaltyLion/CouponImport/Block/Adminhtml/Rule.php
+++ b/app/code/local/LoyaltyLion/CouponImport/Block/Adminhtml/Rule.php
@@ -1,0 +1,23 @@
+<?php
+
+class LoyaltyLion_CouponImport_Block_Adminhtml_Rule extends Mage_Adminhtml_Block_Promo_Quote_Edit_Tab_Main
+{
+  protected function _prepareForm() {
+    // In magento 1.6, we don't have REST API access, so we just add a bulk import option
+    // to the pricerule UI. It's not pretty, but it will get the job done.
+    parent::_prepareForm();
+    $form = $this->getForm();
+    // For other versions, we should hide this - no need to clutter the UI
+    if (Mage::getVersion() < '1.7') {
+      $fieldset = $form->addFieldset('loyaltylion', array('legend'=>Mage::helper('salesrule')->__('LoyaltyLion Vouchers')));
+      $fieldset->addField('ll_codes', 'textarea', array(
+          'name' => 'll_codes',
+          'label' => Mage::helper('salesrule')->__('Voucher Codes'),
+          'title' => Mage::helper('salesrule')->__('Voucher Codes'),
+          'style' => 'width: 98%; height: 100px;',
+      ));
+      $this->setForm($form);
+    }
+    return $form;
+  }
+}

--- a/app/code/local/LoyaltyLion/CouponImport/Model/Rule.php
+++ b/app/code/local/LoyaltyLion/CouponImport/Model/Rule.php
@@ -1,0 +1,48 @@
+<?php
+
+class LoyaltyLion_CouponImport_Model_Rule extends Mage_SalesRule_Model_Rule
+{
+    protected $_unsavedCoupons;
+
+    function loadPost(array $rule) {
+        // At this point we can't persist the codes quite yet,
+        // because the rule they belong to might not have been saved.
+        // So we'll keep them until the _afterSave hook.
+        if (isset($rule['ll_codes'])) {
+            $codes = explode("\n", $rule['ll_codes']);
+            foreach($codes as $i => $code) {
+                $codes[$i] = trim($code);
+            }
+            if (count($codes)) {
+                $this->_unsavedCoupons = $codes;
+            }
+        }
+        return parent::loadPost($rule);
+    }
+
+    protected function _afterSave()
+    {
+        if (count($this->_unsavedCoupons)) {
+            $ruleId = $this->getId();
+            if ($ruleId) {
+                $coupon = Mage::getModel('salesrule/coupon');
+                $now = $this->getResource()->formatDate(
+                    Mage::getSingleton('core/date')->gmtTimestamp()
+                );
+                $expirationDate = $this->toDate;
+                foreach ($this->_unsavedCoupons as $code) {
+                    $code = trim($code);
+                    $coupon->setId(null)
+                        ->setRuleId($ruleId)
+                        ->setUsageLimit(1)
+                        ->setUsagePerCustomer(1)
+                        ->setExpirationDate($expirationDate)
+                        ->setCreatedAt($now)
+                        ->setCode($code)
+                        ->save();
+                }
+            }
+        }
+        return parent::_afterSave();
+    }
+}

--- a/app/code/local/LoyaltyLion/CouponImport/etc/config.xml
+++ b/app/code/local/LoyaltyLion/CouponImport/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <LoyaltyLion_CouponImport>
-            <version>0.1.5</version>
+            <version>0.2.0</version>
         </LoyaltyLion_CouponImport>
     </modules>
     <global>
@@ -10,11 +10,21 @@
             <couponimport>
                 <class>LoyaltyLion_CouponImport_Model</class>
             </couponimport>
+            <salesrule>
+                <rewrite>
+                    <rule>LoyaltyLion_CouponImport_Model_Rule</rule>
+                </rewrite>
+            </salesrule>
         </models>
         <blocks>
             <couponimport>
                 <class>LoyaltyLion_CouponImport_Block</class>
             </couponimport>
+            <adminhtml>
+                <rewrite>
+                    <promo_quote_edit_tab_main>LoyaltyLion_CouponImport_Block_Adminhtml_Rule</promo_quote_edit_tab_main>
+                </rewrite>
+            </adminhtml>
         </blocks>
     </global>
     <admin>


### PR DESCRIPTION
~~NB: I haven't tested this on Magento >= 1.7 yet.~~ All appears well.

What this does is add another input box to the stock Magento pricerule interface, only on versions older than 1.7:
![screenshot 2016-05-25 17 57 57](https://cloud.githubusercontent.com/assets/846136/15548961/563463f6-22a2-11e6-994e-13fee16e7181.png)

It turns out the infrastructure to support multiple codes per pricerule was already there in 1.6, they just hadn't turned it on yet.