### PR TITLE
Magento multisite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## LoyaltyLion for Magento
 
-Version 1.2.0
+Version 1.2.1
 
 ### Compatibility
 
@@ -29,6 +29,7 @@ You'll need to add the LoyaltyLion UI elements to your store before the program 
 
 ### Changelog
 
+* 1.2.1: Add multi-website support for oauth credential submission
 * 1.2.0: Add support for importing voucher codes within your Magento Admin panel (Magento 1.6 only)
 * 1.1.9: Partial compatibility with Magento 1.6
 * 1.1.8: Update signup link

--- a/app/code/local/LoyaltyLion/Core/Model/Observer.php
+++ b/app/code/local/LoyaltyLion/Core/Model/Observer.php
@@ -311,7 +311,7 @@ class LoyaltyLion_Core_Model_Observer {
   private function getVersionInfo() {
     $version_info = Array();
     $version_info['$magento_version'] = Mage::getVersion();
-    if (method_exists(Mage, 'getEdition')) {
+    if (method_exists('Mage', 'getEdition')) {
       $version_info['$magento_platform'] = Mage::getEdition();
     } else {
       $version_info['$magento_platform'] = 'unknown';

--- a/app/code/local/LoyaltyLion/Core/etc/config.xml
+++ b/app/code/local/LoyaltyLion/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <LoyaltyLion_Core>
-      <version>0.0.7</version>
+      <version>0.0.8</version>
     </LoyaltyLion_Core>
   </modules>
   <global>

--- a/app/code/local/LoyaltyLion/CouponImport/controllers/Adminhtml/QuicksetupController.php
+++ b/app/code/local/LoyaltyLion/CouponImport/controllers/Adminhtml/QuicksetupController.php
@@ -183,6 +183,11 @@ class LoyaltyLion_CouponImport_Adminhtml_QuickSetupController extends Mage_Admin
             $websiteID = $website->getId();
             $scope = 'websites';
             $scopeId = $websiteID;
+        } else {
+            // LL is being configured in the `default` scope. 
+            // We'll still report a guess at a websiteID; this could be wrong
+            // but knowing the current website is probably better than nothing.
+            $websiteID = Mage::app()->getWebsite()->getId();
         }
 
         if (!empty($token) && !empty($secret)) {

--- a/app/code/local/LoyaltyLion/CouponImport/controllers/Adminhtml/QuicksetupController.php
+++ b/app/code/local/LoyaltyLion/CouponImport/controllers/Adminhtml/QuicksetupController.php
@@ -175,6 +175,15 @@ class LoyaltyLion_CouponImport_Adminhtml_QuickSetupController extends Mage_Admin
         }
     }
 
+    public function getFirstWebsite() {
+        $websites = Mage::getModel('core/website')->getCollection();
+        foreach($websites as $website) {
+            $id = $website->getId();
+            return $id;
+        }
+        return 0;
+    }
+
     public function LLAPISetup() {
         Mage::log("[LoyaltyLion] Setting up API access");
         $currentUser = Mage::getSingleton('admin/session')->getUser()->getId();
@@ -197,8 +206,8 @@ class LoyaltyLion_CouponImport_Adminhtml_QuickSetupController extends Mage_Admin
         } else {
             // LL is being configured in the `default` scope. 
             // We'll still report a guess at a websiteId; this could be wrong
-            // but knowing the current website is probably better than nothing.
-            $websiteId = Mage::app()->getWebsite()->getId();
+            // but knowing the default website is probably better than nothing.
+            $websiteId = $this->getFirstWebsite();
         }
 
         if (!empty($token) && !empty($secret)) {

--- a/app/code/local/LoyaltyLion/CouponImport/controllers/Adminhtml/QuicksetupController.php
+++ b/app/code/local/LoyaltyLion/CouponImport/controllers/Adminhtml/QuicksetupController.php
@@ -134,7 +134,7 @@ class LoyaltyLion_CouponImport_Adminhtml_QuickSetupController extends Mage_Admin
         return array_merge(array('consumer_key' => $oauth['key'], 'consumer_secret' => $oauth['secret']), $accessToken);
     }
 
-    public function submitOAuthCredentials($credentials, $token, $secret, $websiteID) {
+    public function submitOAuthCredentials($credentials, $token, $secret, $websiteId) {
         if (isset($_SERVER['LOYALTYLION_WEBSITE_BASE'])) {
             $this->loyaltyLionURL = $_SERVER['LOYALTYLION_WEBSITE_BASE'];
         }
@@ -145,8 +145,8 @@ class LoyaltyLion_CouponImport_Adminhtml_QuickSetupController extends Mage_Admin
         $base_url = Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB);
         $credentials['base_url'] = $base_url;
         $credentials['extension_version'] = (string) Mage::getConfig()->getModuleConfig("LoyaltyLion_Core")->version;
-        if ($websiteID > 0) {
-            $credentials['website_id'] = $websiteID;
+        if ($websiteId > 0) {
+            $credentials['website_id'] = $websiteId;
         }
         $resp = $connection->post($setup_uri, $credentials);
         if (isset($resp->error)) {
@@ -173,21 +173,21 @@ class LoyaltyLion_CouponImport_Adminhtml_QuickSetupController extends Mage_Admin
         $secret = $this->getRequest()->getParam('secret');
         $code = $this->getRequest()->getParam('code');
 
-        $websiteID = 0;
+        $websiteId = 0;
         $scope = 'default';
         $scopeId = 0;
 
         if (!empty($code)) {
             // having this means this config is scoped to a particular website, rather than the root 'default' scope
             $website = Mage::getModel('core/website')->load($code);
-            $websiteID = $website->getId();
+            $websiteId = $website->getId();
             $scope = 'websites';
-            $scopeId = $websiteID;
+            $scopeId = $websiteId;
         } else {
             // LL is being configured in the `default` scope. 
-            // We'll still report a guess at a websiteID; this could be wrong
+            // We'll still report a guess at a websiteId; this could be wrong
             // but knowing the current website is probably better than nothing.
-            $websiteID = Mage::app()->getWebsite()->getId();
+            $websiteId = Mage::app()->getWebsite()->getId();
         }
 
         if (!empty($token) && !empty($secret)) {
@@ -227,7 +227,7 @@ class LoyaltyLion_CouponImport_Adminhtml_QuickSetupController extends Mage_Admin
             $credentials = $this->getOAuthCredentials($OAuthConsumerID, $currentUser);
         }
 
-        $result = $this->submitOAuthCredentials($credentials, $token, $secret, $websiteID);
+        $result = $this->submitOAuthCredentials($credentials, $token, $secret, $websiteId);
         if ($result == "ok") {
             Mage::getModel('core/config')->saveConfig('loyaltylion/internals/has_submitted_oauth', 1, $scope, $scopeId);
         }

--- a/app/code/local/LoyaltyLion/CouponImport/controllers/Adminhtml/QuicksetupController.php
+++ b/app/code/local/LoyaltyLion/CouponImport/controllers/Adminhtml/QuicksetupController.php
@@ -130,11 +130,19 @@ class LoyaltyLion_CouponImport_Adminhtml_QuickSetupController extends Mage_Admin
     }
 
     public function getAccessToken($consumer_id, $userID) {
-        $requestToken = Mage::getModel('oauth/token')->createRequestToken($consumer_id, "https://loyaltylion.com/");
-        $requestToken->authorize($userID, 'admin');
-        $accessToken = $requestToken->convertToAccess();
-        $accessData = $accessToken->getData();
-        return array('access_token' => $accessData['token'], 'access_secret' => $accessData['secret']);
+        $tokenId = Mage::getStoreConfig('loyaltylion/internals/oauth_token_id');
+        if ($tokenId) {
+            $requestToken = Mage::getModel('oauth/token')->load($tokenId);
+            $tokenData = $requestToken->getData();
+        }  else {
+            $requestToken = Mage::getModel('oauth/token')->createRequestToken($consumer_id, "https://loyaltylion.com/");
+            $requestToken->authorize($userID, 'admin');
+            $accessToken = $requestToken->convertToAccess();
+            $tokenData = $accessToken->getData();
+            Mage::getModel('core/config')
+                ->saveConfig('loyaltylion/internals/oauth_token_id', $tokenData['entity_id']);
+        }
+        return array('access_token' => $tokenData['token'], 'access_secret' => $tokenData['secret']);
     }
 
     public function getOAuthCredentials($id, $userID) {

--- a/app/code/local/LoyaltyLion/CouponImport/etc/config.xml
+++ b/app/code/local/LoyaltyLion/CouponImport/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <LoyaltyLion_CouponImport>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
         </LoyaltyLion_CouponImport>
     </modules>
     <global>

--- a/app/design/adminhtml/default/default/template/loyaltylion/system/config/button.phtml
+++ b/app/design/adminhtml/default/default/template/loyaltylion/system/config/button.phtml
@@ -1,41 +1,41 @@
 <script type="text/javascript">
-    //<![CDATA[
-    function doSetup() {
-        var button = $('loyaltylion_setup_button');
-	var token = $('loyaltylion_configuration_loyaltylion_token').value
-	var secret = $('loyaltylion_configuration_loyaltylion_secret').value
-	var path_components = window.location.pathname.split('/')
-	var website_pos = path_components.indexOf('website') + 1
-	var code = ''
-	if (website_pos) {
-	    var code = path_components[website_pos]
-	}
-
-        new Ajax.Request('<?php echo $this->getAjaxSetupUrl() ?>', {
-            method: 'get',
-            parameters: { 'token': token, 'secret': secret, 'code': code },
-            onSuccess: function(transport){
-                switch (transport.responseText) {
-                case "ok":
-                    button.removeClassName('fail').addClassName('success');
-                    button.update("Success");
-                    break;
-                case "not-configured-yet":
-                    button.removeClassName('fail').removeClassName('success');
-                    button.update("Please enter your Token / Secret first");
-                    break;
-		default:
-                    button.removeClassName('success').addClassName('fail');
-		    button.update("Error - are you sure you entered the right Token / Secret?");
-                }
-            },
-            onError: function(transport){
-                button.removeClassName('success').addClassName('fail');
-                button.update("Error");
-            }
-        });
+//<![CDATA[
+function doSetup() {
+    var button = $('loyaltylion_setup_button');
+    var token = $('loyaltylion_configuration_loyaltylion_token').value
+    var secret = $('loyaltylion_configuration_loyaltylion_secret').value
+    var path_components = window.location.pathname.split('/')
+    var website_pos = path_components.indexOf('website') + 1
+    var code = ''
+    if (website_pos) {
+        var code = path_components[website_pos]
     }
-    //]]>
+
+    new Ajax.Request('<?php echo $this->getAjaxSetupUrl() ?>', {
+        method: 'get',
+        parameters: { 'token': token, 'secret': secret, 'code': code },
+        onSuccess: function(transport){
+            switch (transport.responseText) {
+            case "ok":
+                button.removeClassName('fail').addClassName('success');
+                button.update("Success");
+                break;
+            case "not-configured-yet":
+                button.removeClassName('fail').removeClassName('success');
+                button.update("Please enter your Token / Secret first");
+                break;
+            default:
+                button.removeClassName('success').addClassName('fail');
+                button.update("Error - are you sure you entered the right Token / Secret?");
+            }
+        },
+        onError: function(transport){
+            button.removeClassName('success').addClassName('fail');
+            button.update("Error");
+        }
+    });
+}
+//]]>
 </script>
- 
+
 <?php echo $this->getButtonHtml() ?>

--- a/app/design/adminhtml/default/default/template/loyaltylion/system/config/button.phtml
+++ b/app/design/adminhtml/default/default/template/loyaltylion/system/config/button.phtml
@@ -1,12 +1,19 @@
 <script type="text/javascript">
     //<![CDATA[
     function doSetup() {
-        button = $('loyaltylion_setup_button');
-	token = $('loyaltylion_configuration_loyaltylion_token').value
-	secret = $('loyaltylion_configuration_loyaltylion_secret').value
+        var button = $('loyaltylion_setup_button');
+	var token = $('loyaltylion_configuration_loyaltylion_token').value
+	var secret = $('loyaltylion_configuration_loyaltylion_secret').value
+	var path_components = window.location.pathname.split('/')
+	var website_pos = path_components.indexOf('website') + 1
+	var code = ''
+	if (website_pos) {
+	    var code = path_components[website_pos]
+	}
+
         new Ajax.Request('<?php echo $this->getAjaxSetupUrl() ?>', {
             method: 'get',
-            parameters: { 'token':token, 'secret': secret },
+            parameters: { 'token': token, 'secret': secret, 'code': code },
             onSuccess: function(transport){
                 switch (transport.responseText) {
                 case "ok":


### PR DESCRIPTION
Our `core` Magento code was already compatible with multiple websites - `getStoreConfig()` automatically gets the config attached to a `website` where there is one overriding the `default` scope.

All that needed to change was the 'configure API access` button -- it needed to (a) save the credentials with the correct scope and (b) submit a website ID with its credentials.