### PR TITLE
If order->getBaseTotalPaid() is null, assume it is 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## LoyaltyLion for Magento
 
-Version 1.2.1
+Version 1.2.2
 
 ### Compatibility
 
@@ -29,6 +29,7 @@ You'll need to add the LoyaltyLion UI elements to your store before the program 
 
 ### Changelog
 
+* 1.2.2: Bugfix: handle unpaid orders on Magento 1.7 more reliably
 * 1.2.1: Add multi-website support for oauth credential submission
 * 1.2.0: Add support for importing voucher codes within your Magento Admin panel (Magento 1.6 only)
 * 1.1.9: Partial compatibility with Magento 1.6

--- a/app/code/local/LoyaltyLion/Core/Model/Observer.php
+++ b/app/code/local/LoyaltyLion/Core/Model/Observer.php
@@ -65,6 +65,9 @@ class LoyaltyLion_Core_Model_Observer {
 
     $order = $observer->getEvent()->getOrder();
 
+    # We can't track an order without a merchant_id
+    if (!$order || !$order->getId()) return;
+
     $data = array(
       'merchant_id' => $order->getId(),
       'customer_id' => $order->getCustomerId(),
@@ -89,7 +92,8 @@ class LoyaltyLion_Core_Model_Observer {
       $data['payment_status'] = 'paid';
     } else {
       $data['payment_status'] = 'partially_paid';
-      $data['total_paid'] = $order->getBaseTotalPaid();
+      $total_paid = $order->getBaseTotalPaid();
+      $data['total_paid'] = $total_paid === null ? 0 : $total_paid;
     }
 
     if ($order->getCouponCode()) {

--- a/app/code/local/LoyaltyLion/Core/etc/config.xml
+++ b/app/code/local/LoyaltyLion/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <LoyaltyLion_Core>
-      <version>0.0.8</version>
+      <version>0.0.9</version>
     </LoyaltyLion_Core>
   </modules>
   <global>

--- a/build-config.php
+++ b/build-config.php
@@ -14,7 +14,7 @@ return array(
 //single Magento module, the tar-to-connect script will look to make sure this
 //matches the module version.  You can skip this check by setting the 
 //skip_version_compare value to true
-'extension_version'      => '1.2.1',
+'extension_version'      => '1.2.2',
 'skip_version_compare'   => true,
 
 //You can also have the package script use the version in the module you 


### PR DESCRIPTION
Also, avoid submitting an order/create request if the
order has no ID yet, as the request will always fail.

This appears to be an issue for magento 1.7 - a newly created order may have both baseTotalPaid and baseTotalDue return `null`.