### PR TITLE
Recreate rest role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## LoyaltyLion for Magento
 
-Version 1.3.1
+Version 1.3.2
 
 ### Compatibility
 
@@ -29,6 +29,7 @@ You'll need to add the LoyaltyLion UI elements to your store before the program 
 
 ### Changelog
 
+* 1.3.2: Clicking "Configure API access" will now repair broken configurations
 * 1.3.1: Add Client helper to support easier custom activities
 * 1.3.0: PSR-1 & MEQP1 compatibility
 * 1.2.3: Switch to new LoyaltyLion domain

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## LoyaltyLion for Magento
 
-Version 1.3.2
+Version 1.4.0
 
 ### Compatibility
 
@@ -29,7 +29,7 @@ You'll need to add the LoyaltyLion UI elements to your store before the program 
 
 ### Changelog
 
-* 1.3.2: Clicking "Configure API access" will now repair broken configurations
+* 1.4.0: Clicking "Configure API access" will now repair broken configurations
 * 1.3.1: Add Client helper to support easier custom activities
 * 1.3.0: PSR-1 & MEQP1 compatibility
 * 1.2.3: Switch to new LoyaltyLion domain

--- a/app/code/local/LoyaltyLion/Core/etc/config.xml
+++ b/app/code/local/LoyaltyLion/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <LoyaltyLion_Core>
-      <version>0.1.1</version>
+      <version>0.1.2</version>
     </LoyaltyLion_Core>
   </modules>
   <global>

--- a/app/code/local/LoyaltyLion/CouponImport/etc/config.xml
+++ b/app/code/local/LoyaltyLion/CouponImport/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <LoyaltyLion_CouponImport>
-            <version>0.2.2</version>
+            <version>0.2.3</version>
         </LoyaltyLion_CouponImport>
     </modules>
     <global>

--- a/build-config.php
+++ b/build-config.php
@@ -14,7 +14,7 @@ return array(
 //single Magento module, the tar-to-connect script will look to make sure this
 //matches the module version.  You can skip this check by setting the 
 //skip_version_compare value to true
-'extension_version'      => '1.3.2',
+'extension_version'      => '1.4.0',
 'skip_version_compare'   => true,
 
 //You can also have the package script use the version in the module you 

--- a/build-config.php
+++ b/build-config.php
@@ -14,7 +14,7 @@ return array(
 //single Magento module, the tar-to-connect script will look to make sure this
 //matches the module version.  You can skip this check by setting the 
 //skip_version_compare value to true
-'extension_version'      => '1.3.1',
+'extension_version'      => '1.3.2',
 'skip_version_compare'   => true,
 
 //You can also have the package script use the version in the module you 


### PR DESCRIPTION
The 'configure API access' button will now repair most damage you can do to your API configuration, recreating anything you can delete from the UI.

Also refactor things so it should be a bunch more readable.