### PR TITLE
Store token and secret by store id

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Once installed, you can find the LoyaltyLion settings page under the `Customers`
 
 Once installed and correctly configured, this module will
 
-1) Add the LoyaltyLion JavaScript SDK to your layout
+1. Add the LoyaltyLion JavaScript SDK to your layout
 
-2) Track customer signups and order creation/updates to the LoyaltyLion API
+2. Track customer signups and order creation/updates to the LoyaltyLion API
 
-3) Listen for referrals and create referral cookies as needed, and send this information to LoyaltyLion
+3. Listen for referrals and create referral cookies as needed, and send this information to LoyaltyLion
 
 ### What you need to do
 
@@ -29,30 +29,31 @@ You'll need to add the LoyaltyLion UI elements to your store before the program 
 
 ### Changelog
 
-* 1.6.1: Report in-use extensions for diagnostics
-* 1.5.1: Add support for delayed customer authentication
-* 1.5.0: Update to new frontend SDK
-* 1.4.1: Clicking "Configure API access" will now repair broken configurations
-* 1.3.1: Add Client helper to support easier custom activities
-* 1.3.0: PSR-1 & MEQP1 compatibility
-* 1.2.3: Switch to new LoyaltyLion domain
-* 1.2.2: Bugfix: handle unpaid orders on Magento 1.7 more reliably
-* 1.2.1: Add multi-website support for oauth credential submission
-* 1.2.0: Add support for importing voucher codes within your Magento Admin panel (Magento 1.6 only)
-* 1.1.9: Partial compatibility with Magento 1.6
-* 1.1.8: Update signup link
-* 1.1.7: Use `$` namespace for core events
-* 1.1.6: Fix controller/model case sensitivity
-* 1.1.4: Fix default submission URL
-* 1.1.3: Fix oauth credential submission
-* 1.1.2: Eliminate "save config" as a separate button click
-* 1.1.1: Send more information to LL Orders API
-* 1.1.0: Extend the REST API with price rules and vouchers; submit API credentials to LoyaltyLion servers.
-* 1.0.4: customer guest status is boolean
-* 1.0.3: SUPEE-6788 compatibility
-* 1.0.2: supports sending discounts used when tracking orders
-* 1.0.1: supports sending loyaltylion `tracking_id` parameters
-* 1.0.0: initial release
+- 1.7.0: Resolves an issue where observers where firing in the wrong contexts
+- 1.6.1: Report in-use extensions for diagnostics
+- 1.5.1: Add support for delayed customer authentication
+- 1.5.0: Update to new frontend SDK
+- 1.4.1: Clicking "Configure API access" will now repair broken configurations
+- 1.3.1: Add Client helper to support easier custom activities
+- 1.3.0: PSR-1 & MEQP1 compatibility
+- 1.2.3: Switch to new LoyaltyLion domain
+- 1.2.2: Bugfix: handle unpaid orders on Magento 1.7 more reliably
+- 1.2.1: Add multi-website support for oauth credential submission
+- 1.2.0: Add support for importing voucher codes within your Magento Admin panel (Magento 1.6 only)
+- 1.1.9: Partial compatibility with Magento 1.6
+- 1.1.8: Update signup link
+- 1.1.7: Use `$` namespace for core events
+- 1.1.6: Fix controller/model case sensitivity
+- 1.1.4: Fix default submission URL
+- 1.1.3: Fix oauth credential submission
+- 1.1.2: Eliminate "save config" as a separate button click
+- 1.1.1: Send more information to LL Orders API
+- 1.1.0: Extend the REST API with price rules and vouchers; submit API credentials to LoyaltyLion servers.
+- 1.0.4: customer guest status is boolean
+- 1.0.3: SUPEE-6788 compatibility
+- 1.0.2: supports sending discounts used when tracking orders
+- 1.0.1: supports sending loyaltylion `tracking_id` parameters
+- 1.0.0: initial release
 
 ### Building
 

--- a/app/code/local/LoyaltyLion/Core/Block/Sdk.php
+++ b/app/code/local/LoyaltyLion/Core/Block/Sdk.php
@@ -2,7 +2,7 @@
 
 class LoyaltyLion_Core_Block_Sdk extends Mage_Core_Block_Template {
   
-  public function isEnabled() {
+  public function isEnabledForCurrentContext() {
     $token = $this->getToken();
     $secret = $this->getSecret();
 

--- a/app/code/local/LoyaltyLion/Core/Helper/Client.php
+++ b/app/code/local/LoyaltyLion/Core/Helper/Client.php
@@ -6,24 +6,15 @@ if (class_exists('LoyaltyLion_Client', false) == false) {
 
 class LoyaltyLion_Core_Helper_Client extends Mage_Core_Helper_Abstract
 {
-  private $client;
-  private $token;
-  private $secret;
+  private $options = array();
 
   public function __construct() {
-    $this->token = Mage::getStoreConfig('loyaltylion/configuration/loyaltylion_token');
-    $this->secret = Mage::getStoreConfig('loyaltylion/configuration/loyaltylion_secret');
-
-    $options = array();
-
     if (isset($_SERVER['LOYALTYLION_API_BASE'])) {
-      $options['base_uri'] = $_SERVER['LOYALTYLION_API_BASE'];
+      $this->options['base_uri'] = $_SERVER['LOYALTYLION_API_BASE'];
     }
-
-    $this->client = new LoyaltyLion_Client($this->token, $this->secret, $options);
   }
 
-  public function client() {
-    return $this->client;
+  public function client($token, $secret) {
+    return $this->client = new LoyaltyLion_Client($token, $secret, $this->options);
   }
 }

--- a/app/code/local/LoyaltyLion/Core/Helper/Client.php
+++ b/app/code/local/LoyaltyLion/Core/Helper/Client.php
@@ -15,6 +15,6 @@ class LoyaltyLion_Core_Helper_Client extends Mage_Core_Helper_Abstract
   }
 
   public function client($token, $secret) {
-    return $this->client = new LoyaltyLion_Client($token, $secret, $this->options);
+    return new LoyaltyLion_Client($token, $secret, $this->options);
   }
 }

--- a/app/code/local/LoyaltyLion/Core/Model/Observer.php
+++ b/app/code/local/LoyaltyLion/Core/Model/Observer.php
@@ -4,26 +4,23 @@ class LoyaltyLion_Core_Model_Observer {
 
   private $client;
   private $session;
-  private $tokensByStoreId = [];
 
   public function __construct() {
-    if (!$this->isEnabled()) return;
-
     $this->client = Mage::helper('loyaltylion/client')->client();
-
     $this->session = Mage::getSingleton('core/session');
   }
 
+  /**
+   * If no storeId is passed here, we can safely pick the current store scope
+   * from Magento. This mirrors the functionality of `Mage::getStoreConfig` but makes
+   * it clearer to us what store is in scope.   * 
+   */
   private function isEnabled($storeId = null) {
     if (is_null($storeId)) $storeId = Mage::app()->getStore()->getId();
 
-    if (empty($this->tokensByStoreId[$storeId])) {
-      $this->findTokensByStoreId($storeId);
-    }
+    $tokensForStore = $this->findTokensByStoreId($storeId);
 
-    $tokensForStore = $this->tokensByStoreId[$storeId];
     if (empty($tokensForStore['token']) || empty($tokensForStore['secret'])) return false;
-
     return true;
   }
 
@@ -31,9 +28,7 @@ class LoyaltyLion_Core_Model_Observer {
     $token = Mage::getStoreConfig('loyaltylion/configuration/loyaltylion_token', $storeId);
     $secret = Mage::getStoreConfig('loyaltylion/configuration/loyaltylion_secret', $storeId);
 
-    $this->tokensByStoreId[$storeId] = array("token" => $token, "secret" => $secret);
-
-    return $this->tokensByStoreId[$storeId];
+    return array("token" => $token, "secret" => $secret);
   }
 
   private function getItems($orderId) {

--- a/app/code/local/LoyaltyLion/Core/Model/Observer.php
+++ b/app/code/local/LoyaltyLion/Core/Model/Observer.php
@@ -149,7 +149,6 @@ class LoyaltyLion_Core_Model_Observer {
 
     if (!$this->isEnabled($customer->getStoreId())) return;
 
-
     // this event is fired at multiple times during checkout before the customer has actually been saved,
     // so we'll ignore most of those events
     if (!$customer->getId()) return;

--- a/app/code/local/LoyaltyLion/Core/etc/config.xml
+++ b/app/code/local/LoyaltyLion/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <LoyaltyLion_Core>
-      <version>0.3.0</version>
+      <version>1.7.0</version>
     </LoyaltyLion_Core>
   </modules>
   <global>

--- a/app/design/frontend/base/default/template/loyaltylion/core/sdk.phtml
+++ b/app/design/frontend/base/default/template/loyaltylion/core/sdk.phtml
@@ -1,4 +1,4 @@
-<?php if ($this->isEnabled()): ?>
+<?php if ($this->isEnabledForCurrentContext()): ?>
   <script>
     !function(t,n){function o(n){var o=t.getElementsByTagName("script")[0],i=t.createElement("script");i.src=n,i.crossOrigin="",o.parentNode.insertBefore(i,o)}if(!n.isLoyaltyLion){window.loyaltylion=n,void 0===window.lion&&(window.lion=n),n.version=2,n.isLoyaltyLion=!0;var i=new Date,e=i.getFullYear().toString()+i.getMonth().toString()+i.getDate().toString();o("https://<?php echo $this->getLoaderUrl() ?>?t="+e);var r=!1;n.init=function(t){if(r)throw new Error("Cannot call lion.init more than once");r=!0;var a=n._token=t.token;if(!a)throw new Error("Token must be supplied to lion.init");for(var l=[],s="_push configure bootstrap shutdown on removeListener authenticateCustomer".split(" "),c=0;c<s.length;c+=1)!function(t,n){t[n]=function(){l.push([n,Array.prototype.slice.call(arguments,0)])}}(n,s[c]);o("https://<?php echo $this->getSdkHost() ?>/sdk/start/"+a+".js?t="+e+i.getHours().toString()),n._initData=t,n._buffer=l}}}(document,window.loyaltylion||[]);
     <?php if (Mage::getSingleton('customer/session')->isLoggedIn()): ?>

--- a/build-config.php
+++ b/build-config.php
@@ -14,7 +14,7 @@ return array(
 //single Magento module, the tar-to-connect script will look to make sure this
 //matches the module version.  You can skip this check by setting the 
 //skip_version_compare value to true
-'extension_version'      => '1.6.1',
+'extension_version'      => '1.7.0',
 'skip_version_compare'   => true,
 
 //You can also have the package script use the version in the module you 


### PR DESCRIPTION
We appear to have an issue where in some cases we are receiving orders that we shouldn't. For example when the Magento instance has a multi-store setup we should only see for stores with this plugin enabled however routinely we receive orders for other stores.

I've not been able to full recreate this issue, however the following at least fixes one issue where updating / editing an order in the Admin UI did process and send us an order when It shouldn't have.

This happens because when we fetched the token and secret via the config routes in the observers constructor we never passed a store ID. In the UI this is fine, Magento has some internal context that tracks where a customer is. However, this context is missing when in an admin state thus it falls back to its default store. If this default store is configured for LL then all stores are (from an admin perspective)

We can resolve this by ensuring that we pass the correct storeId's around, we can get these from the instances that are passed to the observer actions (`$order->getStoreId()`).

![](https://media.giphy.com/media/OtdmwbhlwJoNa/giphy.gif)